### PR TITLE
Improve Login Instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ accs submit {:problem_alphabet} # to use submit function
 - ログイン
 
 ```bash
-oj login
+oj login https://atcoder.jp/
 > Username: kashihararara
 > Password:
 ```


### PR DESCRIPTION
`oj` seems to require the user to specify which site they want to submit. [oj Japanese documentation](https://github.com/online-judge-tools/oj/blob/master/docs/getting-started.ja.md)

Since this tool focuses on AtCoder, I've added it directly to the documentation.

Thanks for this tool! Looking forward to trying it out.