### PR TITLE
Add support for current AtCoder

### DIFF
--- a/Sources/AtCoderLibrary/API/OjApiCommand.swift
+++ b/Sources/AtCoderLibrary/API/OjApiCommand.swift
@@ -5,24 +5,10 @@ enum OjApiCommand {
     static func getAllTasks(url: String, ojApiPath: String) throws -> (contest: Contest, problems: [Problem]) {
         let contest = try OjApiCommand.getContest(url: url, ojApiPath: ojApiPath)
         var problems = [Problem]()
-        let operation = BlockOperation()
-        var error: Error?
-        contest.problems.forEach { problem in
-            operation.addExecutionBlock {
-                do {
-                    let problem = try OjApiCommand.getProblem(url: problem.url, ojApiPath: ojApiPath)
-                        .apply(context: problem.context)
-                    problems.append(problem)
-                } catch(let e) {
-                    error = e
-                    operation.cancel()
-                }
-            }
-        }
-        operation.start()
-
-        if operation.isCancelled, let error = error {
-            throw error
+        for problem in contest.problems {
+            let problem = try OjApiCommand.getProblem(url: problem.url, ojApiPath: ojApiPath)
+                .apply(context: problem.context)
+            problems.append(problem)
         }
         return (contest, problems)
     }

--- a/Sources/AtCoderLibrary/Command/New.swift
+++ b/Sources/AtCoderLibrary/Command/New.swift
@@ -26,7 +26,7 @@ public struct New: ParsableCommand {
         try FileManager.default.createDirectory(atPath: contestName, withIntermediateDirectories: true)
         FileManager.default.changeCurrentDirectoryPath(contestName)
 
-        let alphabets = problems.map(\.context.alphabet).map(Character.init)
+        let alphabets = problems.map(\.context.alphabet)
         try PackageSwift(contestName: contestName, alphabets: alphabets).codeGenerate()
         try Readme(contest: contest, problems: problems).codeGenerate()
         try problems.forEach {

--- a/Sources/AtCoderLibrary/Command/New/Templates/PackageSwift.swift
+++ b/Sources/AtCoderLibrary/Command/New/Templates/PackageSwift.swift
@@ -1,6 +1,6 @@
 struct PackageSwift: CodeTemplate {
     let contestName: String
-    let alphabets: [Character]
+    let alphabets: [String]
     let fileName = "Package.swift"
     let directory: String? = nil
     var source: String {
@@ -12,8 +12,7 @@ struct PackageSwift: CodeTemplate {
             name: "\(contestName.uppercased())",
             dependencies: [],
             targets: [
-        \(alphabets.sorted()
-                    .map {
+        \(alphabets.map {
         """
                 .target(name: "\($0)"),
                 .testTarget(name: "\($0)Tests", dependencies: ["\($0)", "TestLibrary"]),

--- a/Tests/AtCoderLibraryTests/Command/New/Generator/PackageTests.swift
+++ b/Tests/AtCoderLibraryTests/Command/New/Generator/PackageTests.swift
@@ -5,7 +5,7 @@ import Foundation
 final class PackageTests: XCTestCase {
     func test() throws {
         let contestName = "abc001"
-        let alphabets: [Character] = ["A", "B", "C"]
+        let alphabets = ["A", "B", "C"]
         let package = PackageSwift(contestName: contestName, alphabets: alphabets)
         let expected = """
         // swift-tools-version:5.3


### PR DESCRIPTION
## Description
### As-is
- Parallel downloading of AtCoder problems got restricted with "Too many requests" error.
- As they started to use `Ex` for IDs of the hardest problems, `Character.init` caused a crash.

### To-be
Added support for current AtCoder with following fixes:
- Stopped parallel downloading of AtCoder problems.
- Replaced `Character` usages with `String`.

## Tests by the developer
- Tested that I could download the `abc308` problems by running `accs new abc308`.
- Tested that the generated project can be opened and works perfectly.