### PR TITLE
Add support for submission to the latest AtCoder contests

### DIFF
--- a/Sources/AtCoderLibrary/API/Response.swift
+++ b/Sources/AtCoderLibrary/API/Response.swift
@@ -9,6 +9,10 @@ extension OjApiCommand {
         let result: Problem
     }
     
+    struct GuessLanguageResponse: Decodable {
+        let result: Language
+    }
+    
     struct SubmitCodeResponse: Decodable {
         let result: Result
         
@@ -56,4 +60,9 @@ struct Context: Decodable {
         let name: String
         let url: URL
     }
+}
+
+struct Language: Decodable {
+    let id: String
+    let description: String
 }

--- a/Sources/AtCoderLibrary/Command/Submit.swift
+++ b/Sources/AtCoderLibrary/Command/Submit.swift
@@ -8,8 +8,8 @@ public struct Submit: ParsableCommand {
         abstract: "Submit a your code."
     )
 
-    @Argument(help: "Alphabet of the problem to be submitted.", transform: Character.init)
-    var task: Character
+    @Argument(help: "Alphabet of the problem to be submitted.")
+    var task: String
     
     @Flag(name: .shortAndLong, help: "Run a UnitTest before submitting.")
     var runTest: Bool = false

--- a/Sources/AtCoderLibrary/Command/Submit/RunTest.swift
+++ b/Sources/AtCoderLibrary/Command/Submit/RunTest.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftShell
 
 enum RunTest {
-    static func sampleCase(task: Character) throws {
+    static func sampleCase(task: String) throws {
         try runAndPrint("swift", "test", "--filter", "\(task.uppercased())Tests/testExample")
     }
 }


### PR DESCRIPTION
## Description
### As-is
- When `Ex` is used as an alphabet of the hardest problem:
  - `Character.init` caused a crash when a user tried to **submit the code**, which was missing in #2.
  - Users couldn't submit their code, because `h` is used as an ID of the problem.
  (ex: https://atcoder.jp/contests/abc308/tasks/abc308_h)
- Because AtCoder changed the language ID of Swift (4055 -> 5014), users couldn't submit their code.
### To-be
Added support for submission to the latest AtCoder contests:
- Replaced all the `Character` usages with `String`.
- Users can submit their code even if the alphabet of the problem is `Ex`, by fetching the problem info every time.
- Users can submit their code, by guessing language ID every time.

## Tests by the developer
- Tested that I can submit my code for `abc308` problems by running `accs submit d`.
- Tested that I can submit my code for `abc308` problems by running `accs submit ex` or `accs submit Ex`.